### PR TITLE
fix(types): removed a typo

### DIFF
--- a/src/arclight/core/types.hpp
+++ b/src/arclight/core/types.hpp
@@ -34,7 +34,7 @@ using AddressT  = uintptr_t;
 	using SystemT = u64;
 #elif ARC_MACHINE_BITS == 32
 	using SystemT = u32;
-#elif AARC_MACHINE_BITS == 16
+#elif ARC_MACHINE_BITS == 16
 	using SystemT = u16;
 #else
 	using SystemT = u32;


### PR DESCRIPTION
This pull request removes a typo in the 16 bit case of the `types.hpp` specification.